### PR TITLE
Merge PR #412 from 'scopatz/nanorc'

### DIFF
--- a/python.nanorc
+++ b/python.nanorc
@@ -14,20 +14,21 @@ color cyan "\<(__builtin__|__dict__|__methods__|__members__|__class__|__bases__|
 ## built-in functions
 color cyan "\<(abs|append|apply|buffer|callable|chr|clear|close|closed|cmp|coerce|compile|complex|conjugate|copy|count|delattr|dir|divmod|eval|execfile|exec|extend|fileno|filter|float|flush|get|getattr|globals|has_key|hasattr|hash|hex|id|index|input|insert|int|intern|isatty|isinstance|issubclass|items|keys|len|list|locals|long|map|max|min|mode|name|oct|open|ord|pop|pow|print|range|raw_input|read|readline|readlines|reduce|reload|remove|repr|reverse|round|seek|setattr|slice|softspace|sort|str|tell|truncate|tuple|type|unichr|unicode|update|values|vars|write|writelines|xrange|zip|bool)\>"
 ## built-in functions that were previously keywords
-color brightblue "\<(print|exec)\>([[:space:]]|$)"
+color brightcyan "\<(print|exec)\>([[:space:]]|$)"
 ## special method names
 color cyan "\<(__abs__|__add__|__and__|__call__|__cmp__|__coerce__|__complex__|__concat__|__contains__|__del__|__delattr__|__delitem__|__delslice__|__div__|__divmod__|__float__|__getattr__|__getitem__|__getslice__|__hash__|__hex__|__init__|__int__|__inv__|__invert__|__len__|__long__|__lshift__|__mod__|__mul__|__neg__|__nonzero__|__oct__|__or__|__pos__|__pow__|__radd__|__rand__|__rcmp__|__rdiv__|__rdivmod__|__repeat__|__repr__|__rlshift__|__rmod__|__rmul__|__ror__|__rpow__|__rrshift__|__rshift__|__rsub__|__rxor__|__setattr__|__setitem__|__setslice__|__str__|__sub__|__xor__|__bool__)\>"
 ## exception classes
-color cyan "\<(Exception|StandardError|ArithmeticError|LookupError|EnvironmentError|AssertionError|AttributeError|EOFError|FloatingPointError|IOError|ImportError|IndexError|KeyError|KeyboardInterrupt|MemoryError|NameError|NotImplementedError|OSError|OverflowError|RuntimeError|SyntaxError|SystemError|SystemExit|TypeError|UnboundLocalError|UnicodeError|ValueError|WindowsError|ZeroDivisionError)\>"
+color green "\<(Exception|StandardError|ArithmeticError|LookupError|EnvironmentError|AssertionError|AttributeError|EOFError|FloatingPointError|IOError|ImportError|IndexError|KeyError|KeyboardInterrupt|MemoryError|NameError|NotImplementedError|OSError|OverflowError|RuntimeError|SyntaxError|SystemError|SystemExit|TypeError|UnboundLocalError|UnicodeError|ValueError|WindowsError|ZeroDivisionError)\>"
 ## types
-color brightcyan "\<(NoneType|TypeType|IntType|LongType|FloatType|ComplexType|StringType|UnicodeType|BufferType|TupleType|ListType|DictType|FunctionType|LambdaType|CodeType|ClassType|UnboundMethodType|InstanceType|MethodType|BuiltinFunctionType|BuiltinMethodType|ModuleType|FileType|XRangeType|TracebackType|FrameType|SliceType|EllipsisType)\>"
+color green "\<(NoneType|TypeType|IntType|LongType|FloatType|ComplexType|StringType|UnicodeType|BufferType|TupleType|ListType|DictType|FunctionType|LambdaType|CodeType|ClassType|UnboundMethodType|InstanceType|MethodType|BuiltinFunctionType|BuiltinMethodType|ModuleType|FileType|XRangeType|TracebackType|FrameType|SliceType|EllipsisType)\>"
 ## definitions
-color brightcyan "def [a-zA-Z_0-9]+" 
+color green "def [a-zA-Z_0-9]+"
 ## keywords
-color brightblue "\<(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|map|not|or|pass|raise|return|try|with|while|yield)\>"
+color brightred "\<(and|as|from|import|not|or)\>"
+color brightcyan "\<(assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|global|if|in|is|lambda|map|pass|raise|return|try|with|while|yield)\>"
 
 ## decorators
-color brightgreen "@.*[(]"
+color brightgreen "@[a-zA-Z_0-9]+"
 
 ## operators
 color magenta "[.:;,+*|=!\%@]" "<" ">" "/" "-" "&"
@@ -40,17 +41,18 @@ icolor brightyellow "\b(([1-9][0-9]+)|0+)\.[0-9]+j?\b" "\b([1-9][0-9]*[Lj]?)\b" 
 
 
 ## strings
-color yellow "['][^']*[^\\][']" "[']{3}.*[^\\][']{3}"
-color yellow "["][^"]*[^\\]["]" "["]{3}.*[^\\]["]{3}"
+color yellow "['](\\.|[^'])*[']" "[']{3}(\\.|.)*[']{3}"
+color yellow "["](\\.|[^"])*["]" "["]{3}(\\.|.)*["]{3}"
 
 ## comments
-color green "^#.*|[[:space:]]#.*$"
+color brightblue "^#.*|[[:space:]]#.*$"
 
 ## block comments
-color yellow start=""""[^"]" end=""""" start="'''[^']" end="'''"
+color yellow start=""""([^"),]|$)" end="(^|[^(\])""""
+color yellow start="'''([^'),]|$)" end="(^|[^(\])'''"
 
 ## trailing spaces
 color ,green "[[:space:]]+$"
 
 ## reminders
-color brightwhite,yellow "(FIXME|TODO|XXX)"
+color brightwhite,yellow "\<(FIXME|TODO|XXX)\>"


### PR DESCRIPTION
PR [#412](https://github.com/scopatz/nanorc/pull/412)
[Python] Improve colorings and fix bugs
- Improve colorings based on iPython (colors=Linux): - Green for exceptions and function names. - Red for keywords such as `from` and `not`. - Cyan for keywords such as `for` and `if`.
- Fix empty strings not correctly highlighted.
- Fix block comments not correctly highlighted when nothing follows `===`.
- Add support for "TODO".